### PR TITLE
Remove file names from URLs

### DIFF
--- a/assets/javascripts/components/document_card.jsx
+++ b/assets/javascripts/components/document_card.jsx
@@ -116,7 +116,7 @@ class DocumentCardComponent extends Component {
           <div className="ev-document-card__body-left">
             <div className="ev-document-card__text-title">{doc.fileName}</div>
             <div className="ev-document-card__text-primary">{prettyBytes(doc.fileSize)}</div>
-            <div className="ev-document-card__text-secondary">{this.formatDate(doc.createdAt)}</div>
+            <div className="ev-document-card__text-secondary">{this.formatDate(doc.created_at)}</div>
           </div>
           <div className="ev-document-card__body-right">
             {!this.isDisabled() && <a href={doc.shareUrl()} className="ev-document-card__open" target="_blank"></a>}

--- a/assets/javascripts/components/document_card.jsx
+++ b/assets/javascripts/components/document_card.jsx
@@ -114,7 +114,7 @@ class DocumentCardComponent extends Component {
         </DocumentCardMediaComponent>
         <div className="ev-document-card__body">
           <div className="ev-document-card__body-left">
-            <div className="ev-document-card__text-title">{doc.fileName}</div>
+            <div className="ev-document-card__text-title">{doc.name}</div>
             <div className="ev-document-card__text-primary">{prettyBytes(doc.fileSize)}</div>
             <div className="ev-document-card__text-secondary">{this.formatDate(doc.created_at)}</div>
           </div>

--- a/assets/javascripts/components/document_card.jsx
+++ b/assets/javascripts/components/document_card.jsx
@@ -115,7 +115,7 @@ class DocumentCardComponent extends Component {
         <div className="ev-document-card__body">
           <div className="ev-document-card__body-left">
             <div className="ev-document-card__text-title">{doc.name}</div>
-            <div className="ev-document-card__text-primary">{prettyBytes(doc.fileSize)}</div>
+            <div className="ev-document-card__text-primary">{prettyBytes(doc.size)}</div>
             <div className="ev-document-card__text-secondary">{this.formatDate(doc.created_at)}</div>
           </div>
           <div className="ev-document-card__body-right">

--- a/assets/javascripts/components/document_card_media.jsx
+++ b/assets/javascripts/components/document_card_media.jsx
@@ -27,14 +27,14 @@ class DocumentCardMediaComponent extends Component {
 
   renderProgressStatus() {
     const {action, doc, progress} = this.props;
-    const downloadedBytes = Math.round(progress * doc.fileSize);
+    const downloadedBytes = Math.round(progress * doc.size);
 
     return [
       <div key="1" className="ev-document-card__media-percentage">
         {Math.round(progress * 100)}%
       </div>,
       <div key="2" className="ev-document-card__media-bytes">
-        {prettyBytes(downloadedBytes)} of {prettyBytes(doc.fileSize)} {action}ed
+        {prettyBytes(downloadedBytes)} of {prettyBytes(doc.size)} {action}ed
       </div>
     ];
   }

--- a/assets/javascripts/components/document_download_card.jsx
+++ b/assets/javascripts/components/document_download_card.jsx
@@ -108,7 +108,7 @@ class DocumentDownloadCardComponent extends Component {
             {doc && doc.name}
           </div>
           <div className={`ev-document-card__text-primary ${!doc && 'ev-document-card__text-primary--download-loading'}`}>
-            {doc && prettyBytes(doc.fileSize)}
+            {doc && prettyBytes(doc.size)}
           </div>
         </div>
         <div className="ev-document-card__controls">

--- a/assets/javascripts/components/document_download_card.jsx
+++ b/assets/javascripts/components/document_download_card.jsx
@@ -22,7 +22,7 @@ class DocumentDownloadCardComponent extends Component {
   triggerBrowserDownload(url) {
     const link = document.createElement('a')
     link.href = url;
-    link.download = this.props.doc.fileName;
+    link.download = this.props.doc.name;
 
     if (detectBrowser().name === 'firefox') {
       const event = new MouseEvent('click', {bubbles: true, cancelable: true, view: window});
@@ -105,7 +105,7 @@ class DocumentDownloadCardComponent extends Component {
         />
         <div className="ev-document-card__body ev-document-card__body--download">
           <div className={`ev-document-card__text-title ev-document-card__text-title--download ${!doc && 'ev-document-card__text-title--download-loading'}`}>
-            {doc && doc.fileName}
+            {doc && doc.name}
           </div>
           <div className={`ev-document-card__text-primary ${!doc && 'ev-document-card__text-primary--download-loading'}`}>
             {doc && prettyBytes(doc.fileSize)}

--- a/assets/javascripts/components/document_list.jsx
+++ b/assets/javascripts/components/document_list.jsx
@@ -8,7 +8,7 @@ import DocumentCardComponent from './document_card.jsx';
 
 function sortDocuments(documents) {
   return documents.sort(function(a, b) {
-    return new Date(b.createdAt) - new Date(a.createdAt)
+    return new Date(b.created_at) - new Date(a.created_at)
   });
 }
 

--- a/assets/javascripts/components/download.jsx
+++ b/assets/javascripts/components/download.jsx
@@ -32,7 +32,7 @@ class DownloadComponent extends Component {
       .get(urlData.hash, { username })
       .then((gaiaDocument) => {
         this.setState({ document: gaiaDocument });
-        window.document.title = `${gaiaDocument.fileName} - Envelop`;
+        window.document.title = `${gaiaDocument.name} - Envelop`;
 
         if (gaiaDocument.isUploading()) {
           setTimeout(() => this.fetchDocument(), Constants.DOWNLOAD_FILE_REFRESH);

--- a/assets/javascripts/lib/document_remover.js
+++ b/assets/javascripts/lib/document_remover.js
@@ -9,7 +9,7 @@ class DocumentRemover {
   }
 
   remove() {
-    if (this.gaiaDocument.numParts > 1) {
+    if (this.gaiaDocument.num_parts > 1) {
       return this.removeParts();
     } else {
       return this.removeRawFile(this.gaiaDocument.url);

--- a/assets/javascripts/lib/document_remover.js
+++ b/assets/javascripts/lib/document_remover.js
@@ -12,7 +12,7 @@ class DocumentRemover {
     if (this.gaiaDocument.numParts > 1) {
       return this.removeParts();
     } else {
-      return this.removeRawFile(this.gaiaDocument.filePath);
+      return this.removeRawFile(this.gaiaDocument.url);
     }
   }
 

--- a/assets/javascripts/lib/document_uploader.js
+++ b/assets/javascripts/lib/document_uploader.js
@@ -38,7 +38,7 @@ class DocumentUploader {
 
   uploadRawFile(contents) {
     const options = { contentType: 'application/octet-stream' };
-    return putPublicFile(this.serializedDocument.filePath, contents, options);
+    return putPublicFile(this.serializedDocument.url, contents, options);
   }
 }
 

--- a/assets/javascripts/lib/document_uploader.js
+++ b/assets/javascripts/lib/document_uploader.js
@@ -10,7 +10,7 @@ class DocumentUploader {
   constructor(serializedDocument) {
     this.serializedDocument = serializedDocument;
     this.reader = new FileReader();
-    this.progress = new ProgressRegister(serializedDocument.fileSize);
+    this.progress = new ProgressRegister(serializedDocument.size);
   }
 
   upload(file) {
@@ -19,7 +19,7 @@ class DocumentUploader {
         const rawFilePromise = this.uploadRawFile(evt.target.result);
         rawFilePromise
           .then(() => {
-            this.progress.add(this.serializedDocument.fileSize);
+            this.progress.add(this.serializedDocument.size);
             resolve(this.serializedDocument);
           });
       }

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -45,7 +45,7 @@ class GaiaDocument extends WithFile(Record) {
     return new this({
       ...raw,
       fileName: raw.fileName,
-      filePath: (raw.filePath || raw.url),
+      url: raw.url,
       fileSize: raw.fileSize || raw.size,
       created_at: new Date(raw.created_at),
       version: raw.version || 1
@@ -123,14 +123,13 @@ class GaiaDocument extends WithFile(Record) {
 
       // Ignore other serialized fields
       fileName: this.version > 1 ? this.fileName : undefined,
-      filePath: undefined,
       fileSize: undefined,
       numParts: undefined,
 
       // Backwards compatibility
       num_parts: this.numParts || null,
       size: this.fileSize || null,
-      url: this.filePath || null,
+      url: this.url || null,
       uploaded: this.uploaded || null
     };
   }
@@ -154,14 +153,10 @@ class GaiaDocument extends WithFile(Record) {
     this.fileSize = value;
   }
 
-  set url(value) {
-    this.filePath = value;
-  }
-
   get fileName() {
     if (this._fileName) { return this._fileName; }
-    if (!this.filePath) { return null; }
-    return this._fileName = this.filePath.split('/').pop();
+    if (!this.url) { return null; }
+    return this._fileName = this.url.split('/').pop();
   }
 
   set fileName(value) {

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -29,7 +29,7 @@ class GaiaDocument extends WithFile(Record) {
   }
   static fromFile(file) {
     return new this({
-      fileName: file.name,
+      name: file.name,
       created_at: new Date(),
       fileSize: file.size,
       content_type: file.name.split('.').pop(),
@@ -44,7 +44,7 @@ class GaiaDocument extends WithFile(Record) {
 
     return new this({
       ...raw,
-      fileName: raw.fileName,
+      name: raw.name,
       url: raw.url,
       fileSize: raw.fileSize || raw.size,
       created_at: new Date(raw.created_at),
@@ -81,6 +81,10 @@ class GaiaDocument extends WithFile(Record) {
     }
     else {
       this.version = version;
+    }
+
+    if (!this.name && this.url) {
+      this.name = this.url.split('/').pop();
     }
   }
 
@@ -122,7 +126,7 @@ class GaiaDocument extends WithFile(Record) {
       version: this.version || null,
 
       // Ignore other serialized fields
-      fileName: this.version > 1 ? this.fileName : undefined,
+      name: this.version > 1 ? this.name : undefined,
       fileSize: undefined,
       numParts: undefined,
 
@@ -141,7 +145,7 @@ class GaiaDocument extends WithFile(Record) {
   }
 
   uniqueKey() {
-    return `${this.fileName}/${this.created_at.getTime()}`;
+    return `${this.name}/${this.created_at.getTime()}`;
   }
 
   // Backwards compatibility
@@ -151,16 +155,6 @@ class GaiaDocument extends WithFile(Record) {
 
   set size(value) {
     this.fileSize = value;
-  }
-
-  get fileName() {
-    if (this._fileName) { return this._fileName; }
-    if (!this.url) { return null; }
-    return this._fileName = this.url.split('/').pop();
-  }
-
-  set fileName(value) {
-    this._fileName = value;
   }
 }
 

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -30,7 +30,7 @@ class GaiaDocument extends WithFile(Record) {
   static fromFile(file) {
     return new this({
       fileName: file.name,
-      createdAt: new Date(),
+      created_at: new Date(),
       fileSize: file.size,
       content_type: file.name.split('.').pop(),
       file: file
@@ -47,7 +47,7 @@ class GaiaDocument extends WithFile(Record) {
       fileName: raw.fileName,
       filePath: (raw.filePath || raw.url),
       fileSize: raw.fileSize || raw.size,
-      createdAt: new Date(raw.createdAt || raw.created_at),
+      created_at: new Date(raw.created_at),
       version: raw.version || 1
     });
   }
@@ -122,14 +122,12 @@ class GaiaDocument extends WithFile(Record) {
       version: this.version || null,
 
       // Ignore other serialized fields
-      createdAt: undefined,
       fileName: this.version > 1 ? this.fileName : undefined,
       filePath: undefined,
       fileSize: undefined,
       numParts: undefined,
 
       // Backwards compatibility
-      created_at: this.createdAt || null,
       num_parts: this.numParts || null,
       size: this.fileSize || null,
       url: this.filePath || null,
@@ -144,14 +142,10 @@ class GaiaDocument extends WithFile(Record) {
   }
 
   uniqueKey() {
-    return `${this.fileName}/${this.createdAt.getTime()}`;
+    return `${this.fileName}/${this.created_at.getTime()}`;
   }
 
   // Backwards compatibility
-  set created_at(value) {
-    this.createdAt = new Date(value);
-  }
-
   set num_parts(value) {
     this.numParts = value;
   }

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -1,4 +1,4 @@
-import randomstring from 'randomstring';
+import uuid from 'uuid/v4';
 
 import { privateUserSession, } from '../lib/blockstack_client';
 import Constants from '../lib/constants';
@@ -13,10 +13,6 @@ const types = {
   video:   ['avi', 'mpeg', 'mpg', 'mp4', 'ogv', 'webm', '3gp', 'mov'],
   archive: ['zip', 'rar', 'tar', 'gz', '7z', 'bz', 'bz2', 'arc'],
 };
-
-function generateHash(length) {
-  return randomstring.generate(length);
-}
 
 const version = 2;
 
@@ -75,7 +71,7 @@ class GaiaDocument extends WithFile(Record) {
 
   async saveLocal() {
     const payload = this.serialize();
-    payload.localId = this.localId || generateHash(20);
+    payload.localId = this.localId || uuid();
 
     const uploader = new LocalDocumentUploader(payload)
     const uploadedDoc = await uploader.upload(this.file);

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -21,12 +21,6 @@ function generateHash(length) {
 const version = 2;
 
 class GaiaDocument extends WithFile(Record) {
-  static get attributes() {
-    return {
-      ...super.attributes,
-      version: null
-    }
-  }
   static fromFile(file) {
     return new this({
       name: file.name,

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -31,7 +31,7 @@ class GaiaDocument extends WithFile(Record) {
     return new this({
       name: file.name,
       created_at: new Date(),
-      fileSize: file.size,
+      size: file.size,
       content_type: file.name.split('.').pop(),
       file: file
     });
@@ -46,7 +46,7 @@ class GaiaDocument extends WithFile(Record) {
       ...raw,
       name: raw.name,
       url: raw.url,
-      fileSize: raw.fileSize || raw.size,
+      size: raw.size,
       created_at: new Date(raw.created_at),
       version: raw.version || 1
     });
@@ -127,12 +127,11 @@ class GaiaDocument extends WithFile(Record) {
 
       // Ignore other serialized fields
       name: this.version > 1 ? this.name : undefined,
-      fileSize: undefined,
       numParts: undefined,
 
       // Backwards compatibility
       num_parts: this.numParts || null,
-      size: this.fileSize || null,
+      size: this.size || null,
       url: this.url || null,
       uploaded: this.uploaded || null
     };
@@ -151,10 +150,6 @@ class GaiaDocument extends WithFile(Record) {
   // Backwards compatibility
   set num_parts(value) {
     this.numParts = value;
-  }
-
-  set size(value) {
-    this.fileSize = value;
   }
 }
 

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -124,16 +124,10 @@ class GaiaDocument extends WithFile(Record) {
       content_type: this.content_type || null,
       localId: this.id || null,
       version: this.version || null,
+      uploaded: this.uploaded || null,
 
       // Ignore other serialized fields
-      name: this.version > 1 ? this.name : undefined,
-      numParts: undefined,
-
-      // Backwards compatibility
-      num_parts: this.numParts || null,
-      size: this.size || null,
-      url: this.url || null,
-      uploaded: this.uploaded || null
+      name: this.version > 1 ? this.name : undefined
     };
   }
 
@@ -145,11 +139,6 @@ class GaiaDocument extends WithFile(Record) {
 
   uniqueKey() {
     return `${this.name}/${this.created_at.getTime()}`;
-  }
-
-  // Backwards compatibility
-  set num_parts(value) {
-    this.numParts = value;
   }
 }
 

--- a/assets/javascripts/lib/gaia_document.js
+++ b/assets/javascripts/lib/gaia_document.js
@@ -39,14 +39,6 @@ class GaiaDocument extends WithFile(Record) {
     this.localId = fields.localId;
     this.uploaded = fields.uploaded;
     this._username = options.username;
-
-    // FIXME:
-    if (this.id) {
-      this.version = this.version || 1;
-    }
-    else {
-      this.version = version;
-    }
   }
 
   getType() {

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -23,7 +23,7 @@ describe('v2', () => {
       await doc.save();
 
       expect(doc.version).toBe(2);
-      expect(doc.filePath).toMatch(/^[a-zA-Z0-9]{24}$/);
+      expect(doc.url).toMatch(/^[a-zA-Z0-9]{24}$/);
       expect(doc.fileName).toEqual('name.pdf');
     });
   });
@@ -45,7 +45,7 @@ describe('v2', () => {
 
       const doc = await GaiaDocument.get('123');
 
-      expect(doc.filePath).toBe('abcdef');
+      expect(doc.url).toBe('abcdef');
       expect(doc.fileName).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
@@ -60,7 +60,7 @@ describe('v2', () => {
       const attributes = {
         id: '123',
         fileName: 'name.pdf',
-        filePath: 'abcdef',
+        url: 'abcdef',
         fileSize: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
         numParts: 2,
@@ -105,7 +105,7 @@ describe('v1', () => {
 
       const doc = await GaiaDocument.get('123');
 
-      expect(doc.filePath).toBe('abcdef/name.pdf');
+      expect(doc.url).toBe('abcdef/name.pdf');
       expect(doc.fileName).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
@@ -119,7 +119,7 @@ describe('v1', () => {
     test('parses payload', async () => {
       const doc = await GaiaDocument.fromGaiaIndex(v1Attributes);
 
-      expect(doc.filePath).toBe('abcdef/name.pdf');
+      expect(doc.url).toBe('abcdef/name.pdf');
       expect(doc.fileName).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
@@ -154,7 +154,7 @@ describe('v1', () => {
     test('serializes from new attributes', async () => {
       const attributes = {
         id: '123',
-        filePath: 'abcdef/name.pdf',
+        url: 'abcdef/name.pdf',
         fileSize: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
         numParts: 2,

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -1,6 +1,8 @@
 import Record from './records/record';
 import GaiaDocument from './gaia_document';
 
+const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 function mockSession(session) {
   Record.config({ session });
 }
@@ -28,7 +30,7 @@ describe('v2', () => {
       await doc.save();
 
       expect(doc.version).toBe(2);
-      expect(doc.url).toMatch(/^[a-zA-Z0-9]{24}$/);
+      expect(doc.url).toMatch(uuidRegex);
       expect(doc.name).toEqual('name.pdf');
     });
   });

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -49,7 +49,7 @@ describe('v2', () => {
       expect(doc.name).toBe('name.pdf');
       expect(doc.size).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
-      expect(doc.numParts).toBe(2);
+      expect(doc.num_parts).toBe(2);
       expect(doc.uploaded).toBe(true);
       expect(doc.version).toBe(2);
     });
@@ -63,7 +63,7 @@ describe('v2', () => {
         url: 'abcdef',
         size: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
-        numParts: 2,
+        num_parts: 2,
         uploaded: true,
         version: 2
       }
@@ -109,7 +109,7 @@ describe('v1', () => {
       expect(doc.name).toBe('name.pdf');
       expect(doc.size).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
-      expect(doc.numParts).toBe(2);
+      expect(doc.num_parts).toBe(2);
       expect(doc.uploaded).toBe(true);
       expect(doc.version).toBe(1);
     });
@@ -123,7 +123,7 @@ describe('v1', () => {
       expect(doc.name).toBe('name.pdf');
       expect(doc.size).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
-      expect(doc.numParts).toBe(2);
+      expect(doc.num_parts).toBe(2);
       expect(doc.uploaded).toBe(true);
       expect(doc.version).toBe(1);
     });
@@ -157,7 +157,7 @@ describe('v1', () => {
         url: 'abcdef/name.pdf',
         size: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
-        numParts: 2,
+        num_parts: 2,
         uploaded: true
       }
 

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -15,7 +15,7 @@ describe('v2', () => {
       mockSession({ putFile: async() => true });
 
       const attributes = {
-        fileName: 'name.pdf',
+        name: 'name.pdf',
         fileSize: 500,
         file: new File([1], '...')
       }
@@ -24,7 +24,7 @@ describe('v2', () => {
 
       expect(doc.version).toBe(2);
       expect(doc.url).toMatch(/^[a-zA-Z0-9]{24}$/);
-      expect(doc.fileName).toEqual('name.pdf');
+      expect(doc.name).toEqual('name.pdf');
     });
   });
 
@@ -33,7 +33,7 @@ describe('v2', () => {
       const v2Attributes = {
         id: '123',
         url: 'abcdef',
-        fileName: 'name.pdf',
+        name: 'name.pdf',
         size: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
         num_parts: 2,
@@ -46,7 +46,7 @@ describe('v2', () => {
       const doc = await GaiaDocument.get('123');
 
       expect(doc.url).toBe('abcdef');
-      expect(doc.fileName).toBe('name.pdf');
+      expect(doc.name).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
@@ -59,7 +59,7 @@ describe('v2', () => {
     test('serializes attributes', async () => {
       const attributes = {
         id: '123',
-        fileName: 'name.pdf',
+        name: 'name.pdf',
         url: 'abcdef',
         fileSize: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
@@ -80,7 +80,7 @@ describe('v2', () => {
         num_parts: 2,
         size: 500,
         url: 'abcdef',
-        fileName: 'name.pdf',
+        name: 'name.pdf',
         uploaded: true
       });
 
@@ -106,7 +106,7 @@ describe('v1', () => {
       const doc = await GaiaDocument.get('123');
 
       expect(doc.url).toBe('abcdef/name.pdf');
-      expect(doc.fileName).toBe('name.pdf');
+      expect(doc.name).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
@@ -120,7 +120,7 @@ describe('v1', () => {
       const doc = await GaiaDocument.fromGaiaIndex(v1Attributes);
 
       expect(doc.url).toBe('abcdef/name.pdf');
-      expect(doc.fileName).toBe('name.pdf');
+      expect(doc.name).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -9,6 +9,11 @@ function serialize(payload) {
   return JSON.parse(JSON.stringify(payload));
 }
 
+test('new documents are version = 2', async () => {
+  const doc = new GaiaDocument({});
+  expect(doc.version).toBe(2);
+});
+
 describe('v2', () => {
   describe('.save', () => {
     test('sets appropriate attributes', async () => {
@@ -100,24 +105,24 @@ describe('v1', () => {
   }
 
   describe('.get', () => {
+    describe('new', () => {
+      test('parses fields', async () => {
+        const doc = new GaiaDocument(v1Attributes);
+
+        expect(doc.url).toBe('abcdef/name.pdf');
+        expect(doc.name).toBe('name.pdf');
+        expect(doc.size).toBe(500);
+        expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
+        expect(doc.num_parts).toBe(2);
+        expect(doc.uploaded).toBe(true);
+        expect(doc.version).toBe(1);
+      });
+    });
+
     test('parses document', async () => {
       mockSession({ getFile: async() => JSON.stringify(v1Attributes) })
 
       const doc = await GaiaDocument.get('123');
-
-      expect(doc.url).toBe('abcdef/name.pdf');
-      expect(doc.name).toBe('name.pdf');
-      expect(doc.size).toBe(500);
-      expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
-      expect(doc.num_parts).toBe(2);
-      expect(doc.uploaded).toBe(true);
-      expect(doc.version).toBe(1);
-    });
-  });
-
-  describe('.fromGaiaIndex', () => {
-    test('parses payload', async () => {
-      const doc = await GaiaDocument.fromGaiaIndex(v1Attributes);
 
       expect(doc.url).toBe('abcdef/name.pdf');
       expect(doc.name).toBe('name.pdf');
@@ -145,6 +150,7 @@ describe('v1', () => {
         num_parts: 2,
         size: 500,
         url: 'abcdef/name.pdf',
+        name: 'name.pdf',
         uploaded: true
       });
 
@@ -175,6 +181,7 @@ describe('v1', () => {
         num_parts: 2,
         size: 500,
         url: 'abcdef/name.pdf',
+        name: 'name.pdf',
         uploaded: true
       });
 

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -48,7 +48,7 @@ describe('v2', () => {
       expect(doc.filePath).toBe('abcdef');
       expect(doc.fileName).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
-      expect(doc.createdAt).toEqual(new Date('2019-07-16T10:47:39.865Z'));
+      expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
       expect(doc.uploaded).toBe(true);
       expect(doc.version).toBe(2);
@@ -62,7 +62,7 @@ describe('v2', () => {
         fileName: 'name.pdf',
         filePath: 'abcdef',
         fileSize: 500,
-        createdAt: new Date('2019-07-16T10:47:39.865Z'),
+        created_at: new Date('2019-07-16T10:47:39.865Z'),
         numParts: 2,
         uploaded: true,
         version: 2
@@ -108,7 +108,7 @@ describe('v1', () => {
       expect(doc.filePath).toBe('abcdef/name.pdf');
       expect(doc.fileName).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
-      expect(doc.createdAt).toEqual(new Date('2019-07-16T10:47:39.865Z'));
+      expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
       expect(doc.uploaded).toBe(true);
       expect(doc.version).toBe(1);
@@ -122,7 +122,7 @@ describe('v1', () => {
       expect(doc.filePath).toBe('abcdef/name.pdf');
       expect(doc.fileName).toBe('name.pdf');
       expect(doc.fileSize).toBe(500);
-      expect(doc.createdAt).toEqual(new Date('2019-07-16T10:47:39.865Z'));
+      expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
       expect(doc.uploaded).toBe(true);
       expect(doc.version).toBe(1);
@@ -156,7 +156,7 @@ describe('v1', () => {
         id: '123',
         filePath: 'abcdef/name.pdf',
         fileSize: 500,
-        createdAt: new Date('2019-07-16T10:47:39.865Z'),
+        created_at: new Date('2019-07-16T10:47:39.865Z'),
         numParts: 2,
         uploaded: true
       }

--- a/assets/javascripts/lib/gaia_document.test.js
+++ b/assets/javascripts/lib/gaia_document.test.js
@@ -16,7 +16,7 @@ describe('v2', () => {
 
       const attributes = {
         name: 'name.pdf',
-        fileSize: 500,
+        size: 500,
         file: new File([1], '...')
       }
       const doc = new GaiaDocument(attributes);
@@ -47,7 +47,7 @@ describe('v2', () => {
 
       expect(doc.url).toBe('abcdef');
       expect(doc.name).toBe('name.pdf');
-      expect(doc.fileSize).toBe(500);
+      expect(doc.size).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
       expect(doc.uploaded).toBe(true);
@@ -61,7 +61,7 @@ describe('v2', () => {
         id: '123',
         name: 'name.pdf',
         url: 'abcdef',
-        fileSize: 500,
+        size: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
         numParts: 2,
         uploaded: true,
@@ -107,7 +107,7 @@ describe('v1', () => {
 
       expect(doc.url).toBe('abcdef/name.pdf');
       expect(doc.name).toBe('name.pdf');
-      expect(doc.fileSize).toBe(500);
+      expect(doc.size).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
       expect(doc.uploaded).toBe(true);
@@ -121,7 +121,7 @@ describe('v1', () => {
 
       expect(doc.url).toBe('abcdef/name.pdf');
       expect(doc.name).toBe('name.pdf');
-      expect(doc.fileSize).toBe(500);
+      expect(doc.size).toBe(500);
       expect(doc.created_at).toEqual(new Date('2019-07-16T10:47:39.865Z'));
       expect(doc.numParts).toBe(2);
       expect(doc.uploaded).toBe(true);
@@ -155,7 +155,7 @@ describe('v1', () => {
       const attributes = {
         id: '123',
         url: 'abcdef/name.pdf',
-        fileSize: 500,
+        size: 500,
         created_at: new Date('2019-07-16T10:47:39.865Z'),
         numParts: 2,
         uploaded: true

--- a/assets/javascripts/lib/gaia_index.js
+++ b/assets/javascripts/lib/gaia_index.js
@@ -5,7 +5,7 @@ import { privateUserSession } from './blockstack_client';
 const version = 1;
 
 function parseDocuments(rawDocuments) {
-  return (rawDocuments || []).map(raw => GaiaDocument.fromGaiaIndex(raw));
+  return (rawDocuments || []).map(raw => new GaiaDocument(raw));
 }
 
 class GaiaIndex {

--- a/assets/javascripts/lib/local_document_uploader.js
+++ b/assets/javascripts/lib/local_document_uploader.js
@@ -6,7 +6,7 @@ class LocalDocumentUploader {
   constructor(serializedDocument) {
     this.serializedDocument = serializedDocument;
     this.reader = new FileReader();
-    this.progress = new ProgressRegister(serializedDocument.fileSize);
+    this.progress = new ProgressRegister(serializedDocument.size);
   }
 
   async upload(file) {
@@ -20,7 +20,7 @@ class LocalDocumentUploader {
         LocalDatabase
           .setItem(documentKey, payload)
           .then(() =>{
-            this.progress.add(this.serializedDocument.fileSize);
+            this.progress.add(this.serializedDocument.size);
             resolve(this.serializedDocument);
           }) ;
       }

--- a/assets/javascripts/lib/partitioned_document_downloader.js
+++ b/assets/javascripts/lib/partitioned_document_downloader.js
@@ -8,7 +8,7 @@ class PartitionedDocumentDownloader {
   constructor(gaiaDocument) {
     this.gaiaDocument = gaiaDocument;
     this.limiter = new Bottleneck({ maxConcurrent: 3 });
-    this.progress = new ProgressRegister(gaiaDocument.fileSize);
+    this.progress = new ProgressRegister(gaiaDocument.size);
   }
 
   async download() {

--- a/assets/javascripts/lib/partitioned_document_downloader.js
+++ b/assets/javascripts/lib/partitioned_document_downloader.js
@@ -65,7 +65,7 @@ class PartitionedDocumentDownloader {
   }
 
   createBlob(partBuffers) {
-    const blobOptions = { name: this.gaiaDocument.fileName, type: this.gaiaDocument.getMimeType() };
+    const blobOptions = { name: this.gaiaDocument.name, type: this.gaiaDocument.getMimeType() };
     return new Blob(partBuffers, blobOptions);
   }
 

--- a/assets/javascripts/lib/partitioned_document_uploader.js
+++ b/assets/javascripts/lib/partitioned_document_uploader.js
@@ -73,7 +73,7 @@ class PartitionedDocumentUploader {
 
     this.cleanupLimiters();
 
-    this.serializedDocument.numParts = this.numParts;
+    this.serializedDocument.num_parts = this.numParts;
 
     return this.serializedDocument;
   }

--- a/assets/javascripts/lib/partitioned_document_uploader.js
+++ b/assets/javascripts/lib/partitioned_document_uploader.js
@@ -12,9 +12,9 @@ function putPublicFile(name, contents) {
 class PartitionedDocumentUploader {
   constructor(serializedDocument) {
     this.partSize = serializedDocument.partSize || Constants.FILE_PART_SIZE;
-    this.numParts = Math.ceil(serializedDocument.fileSize / this.partSize);
+    this.numParts = Math.ceil(serializedDocument.size / this.partSize);
     this.serializedDocument = serializedDocument;
-    this.progress = new ProgressRegister(serializedDocument.fileSize);
+    this.progress = new ProgressRegister(serializedDocument.size);
     this.readLimiter = new Bottleneck({ maxConcurrent: 6 });
     this.uploadLimiter = new Bottleneck({ maxConcurrent: 3 });
   }

--- a/assets/javascripts/lib/partitioned_document_uploader.js
+++ b/assets/javascripts/lib/partitioned_document_uploader.js
@@ -84,7 +84,7 @@ class PartitionedDocumentUploader {
 
   uploadPart(partNumber, partBuffer) {
     const options = { contentType: 'application/octet-stream' };
-    const partUrl = `${this.serializedDocument.filePath}.part${partNumber}`;
+    const partUrl = `${this.serializedDocument.url}.part${partNumber}`;
     return putPublicFile(partUrl, partBuffer, options);
   }
 }

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -36,7 +36,7 @@ const WithFile = (superclass) => {
       return {
         ...super.attributes,
         fileName: null,
-        filePath: null,
+        url: null,
         fileSize: null,
         numParts: null
       }
@@ -60,7 +60,7 @@ const WithFile = (superclass) => {
       }
       else {
         const options = { username: this._username, decrypt: false, verify: false };
-        const fileUrl = await publicSession.getFileUrl(this.filePath, options);
+        const fileUrl = await publicSession.getFileUrl(this.url, options);
         this.downloadProgressCallbacks.forEach((callback) => callback(1));
         return fileUrl;
       }
@@ -101,14 +101,14 @@ const WithFile = (superclass) => {
 
       return new Array(this.numParts)
         .fill(null)
-        .map((_, index) => `${this.filePath}.part${index}`);
+        .map((_, index) => `${this.url}.part${index}`);
     }
 
     serialize() {
       return {
         ...super.serialize(),
         fileName: this.fileName || null,
-        filePath: this.filePath || null,
+        url: this.url || null,
         fileSize: this.fileSize || null,
         numParts: this.numParts || null
       };
@@ -120,7 +120,7 @@ const WithFile = (superclass) => {
   });
 
   klass.beforeSave(async (record) => {
-    record.filePath = record.filePath || `${generateHash(24)}`;
+    record.url = record.url || `${generateHash(24)}`;
 
     record._uploader = getUploader(record, record.uploadProgressCallbacks);
     const modifiedPayload = await record._uploader.upload(record.file);

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -38,7 +38,7 @@ const WithFile = (superclass) => {
         name: null,
         url: null,
         size: null,
-        numParts: null
+        num_parts: null
       }
     }
 
@@ -51,7 +51,7 @@ const WithFile = (superclass) => {
     }
 
     async download() {
-      if (this.numParts && this.numParts > 1) {
+      if (this.num_parts && this.num_parts > 1) {
         this._downloader = new PartitionedDocumentDownloader(this);
         this.downloadProgressCallbacks.forEach((callback) => {
           this._downloader.onProgress(callback);
@@ -97,9 +97,9 @@ const WithFile = (superclass) => {
     }
 
     getPartUrls() {
-      if (!this.numParts) { return []; }
+      if (!this.num_parts) { return []; }
 
-      return new Array(this.numParts)
+      return new Array(this.num_parts)
         .fill(null)
         .map((_, index) => `${this.url}.part${index}`);
     }
@@ -110,7 +110,7 @@ const WithFile = (superclass) => {
         name: this.name || null,
         url: this.url || null,
         size: this.size || null,
-        numParts: this.numParts || null
+        num_parts: this.num_parts || null
       };
     }
   }
@@ -125,7 +125,7 @@ const WithFile = (superclass) => {
     record._uploader = getUploader(record, record.uploadProgressCallbacks);
     const modifiedPayload = await record._uploader.upload(record.file);
 
-    record.numParts = modifiedPayload.numParts;
+    record.num_parts = modifiedPayload.num_parts;
 
     return true;
   });

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -35,7 +35,7 @@ const WithFile = (superclass) => {
     static get attributes() {
       return {
         ...super.attributes,
-        fileName: null,
+        name: null,
         url: null,
         fileSize: null,
         numParts: null
@@ -93,7 +93,7 @@ const WithFile = (superclass) => {
     }
 
     getMimeType() {
-      return mime.lookup(this.fileName) || null;
+      return mime.lookup(this.name) || null;
     }
 
     getPartUrls() {
@@ -107,7 +107,7 @@ const WithFile = (superclass) => {
     serialize() {
       return {
         ...super.serialize(),
-        fileName: this.fileName || null,
+        name: this.name || null,
         url: this.url || null,
         fileSize: this.fileSize || null,
         numParts: this.numParts || null

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -1,5 +1,5 @@
 import mime from 'mime-types';
-import randomstring from 'randomstring';
+import uuid from 'uuid/v4';
 
 import Constants from '../../constants';
 import DocumentRemover from '../../document_remover';
@@ -7,10 +7,6 @@ import DocumentUploader from '../../document_uploader';
 import { publicUserSession as publicSession } from '../../blockstack_client';
 import PartitionedDocumentDownloader from '../../partitioned_document_downloader';
 import PartitionedDocumentUploader from '../../partitioned_document_uploader';
-
-function generateHash(length) {
-  return randomstring.generate(length);
-}
 
 function getUploader(payload, callbacks) {
   let uploader = null;
@@ -110,7 +106,7 @@ const WithFile = (superclass) => {
   });
 
   klass.beforeSave(async (record) => {
-    record.url = record.url || `${generateHash(24)}`;
+    record.url = record.url || uuid();
 
     record._uploader = getUploader(record, record.uploadProgressCallbacks);
     const modifiedPayload = await record._uploader.upload(record.file);

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -15,14 +15,14 @@ function generateHash(length) {
 function getUploader(payload, callbacks) {
   let uploader = null;
 
-  if (payload.fileSize <= Constants.SINGLE_FILE_SIZE_LIMIT) {
+  if (payload.size <= Constants.SINGLE_FILE_SIZE_LIMIT) {
     uploader = new DocumentUploader(payload)
   }
-  else if (payload.fileSize > Constants.SINGLE_FILE_SIZE_LIMIT) {
+  else if (payload.size > Constants.SINGLE_FILE_SIZE_LIMIT) {
     uploader = new PartitionedDocumentUploader(payload)
   }
   else {
-    throw("Cant get uploader - missing 'fileSize'")
+    throw("Cant get uploader - missing 'size'")
   }
 
   callbacks.forEach((callback) => uploader.onProgress(callback));
@@ -37,7 +37,7 @@ const WithFile = (superclass) => {
         ...super.attributes,
         name: null,
         url: null,
-        fileSize: null,
+        size: null,
         numParts: null
       }
     }
@@ -109,7 +109,7 @@ const WithFile = (superclass) => {
         ...super.serialize(),
         name: this.name || null,
         url: this.url || null,
-        fileSize: this.fileSize || null,
+        size: this.size || null,
         numParts: this.numParts || null
       };
     }

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -35,6 +35,7 @@ const WithFile = (superclass) => {
     static get attributes() {
       return {
         ...super.attributes,
+        fileName: null,
         filePath: null,
         fileSize: null,
         numParts: null
@@ -47,16 +48,6 @@ const WithFile = (superclass) => {
       this.file = fields.file;
       this.downloadProgressCallbacks = [];
       this.uploadProgressCallbacks = [];
-    }
-
-    get fileName() {
-      if (this._fileName) { return this._fileName; }
-      if (!this.filePath) { return null; }
-      return this._fileName = this.filePath.split('/').pop();
-    }
-
-    set fileName(value) {
-      this._fileName = value;
     }
 
     async download() {
@@ -116,6 +107,7 @@ const WithFile = (superclass) => {
     serialize() {
       return {
         ...super.serialize(),
+        fileName: this.fileName || null,
         filePath: this.filePath || null,
         fileSize: this.fileSize || null,
         numParts: this.numParts || null
@@ -128,7 +120,7 @@ const WithFile = (superclass) => {
   });
 
   klass.beforeSave(async (record) => {
-    record.filePath = record.filePath || `${generateHash(24)}/${record.fileName}`;
+    record.filePath = record.filePath || `${generateHash(24)}`;
 
     record._uploader = getUploader(record, record.uploadProgressCallbacks);
     const modifiedPayload = await record._uploader.upload(record.file);

--- a/assets/javascripts/lib/records/mixins/with_file.js
+++ b/assets/javascripts/lib/records/mixins/with_file.js
@@ -32,16 +32,6 @@ function getUploader(payload, callbacks) {
 
 const WithFile = (superclass) => {
   const klass = class extends superclass {
-    static get attributes() {
-      return {
-        ...super.attributes,
-        name: null,
-        url: null,
-        size: null,
-        num_parts: null
-      }
-    }
-
     constructor(fields = {}) {
       super(fields);
 

--- a/assets/javascripts/lib/records/record.js
+++ b/assets/javascripts/lib/records/record.js
@@ -44,7 +44,7 @@ class Record {
   static get attributes() {
     return {
       id: null,
-      createdAt: null
+      created_at: null
     };
   }
 
@@ -77,12 +77,12 @@ class Record {
     });
   }
 
-  set createdAt(value) {
-    this.attributes.createdAt = new Date(value);
+  set created_at(value) {
+    this.attributes.created_at = new Date(value);
   }
 
-  get createdAt() {
-    return this.attributes.createdAt;
+  get created_at() {
+    return this.attributes.created_at;
   }
 
   async delete() {
@@ -113,8 +113,8 @@ class Record {
       payload.id = this.id || generateHash(6);
     }
 
-    if (!payload.createdAt) {
-      payload.createdAt = this.createdAt || new Date();
+    if (!payload.created_at) {
+      payload.created_at = this.created_at || new Date();
     }
 
     // TODO: Maybe snakecase keys before upload? or camelize?
@@ -126,7 +126,7 @@ class Record {
 
   serialize() {
     return {
-      createdAt: this.createdAt || null,
+      created_at: this.created_at || null,
       id: this.id || null
     };
   }

--- a/assets/javascripts/lib/records/record.js
+++ b/assets/javascripts/lib/records/record.js
@@ -41,13 +41,6 @@ class Record {
     }
   }
 
-  static get attributes() {
-    return {
-      id: null,
-      created_at: null
-    };
-  }
-
   static beforeSave(callback) {
     this.addHook('beforeSave', callback);
   }
@@ -57,32 +50,13 @@ class Record {
   }
 
   constructor(fields = {}) {
-    this.attributes = {};
-
-    Object.keys(this.constructor.attributes).forEach(attrName => {
-      if (attrName in this) { return; }
-
-      Object.defineProperty(this, attrName, {
-        get() {
-          return this.attributes[attrName];
-        },
-        set(value) {
-          return this.attributes[attrName] = value;
-        }
-      });
-    });
-
     Object.keys(fields).forEach(attrName => {
       this[attrName] = fields[attrName];
     });
-  }
 
-  set created_at(value) {
-    this.attributes.created_at = new Date(value);
-  }
-
-  get created_at() {
-    return this.attributes.created_at;
+    if (this.created_at) {
+      this.created_at = new Date(this.created_at);
+    }
   }
 
   async delete() {

--- a/assets/javascripts/lib/records/record.test.js
+++ b/assets/javascripts/lib/records/record.test.js
@@ -11,18 +11,7 @@ const session = {
 
 Record.config({ session });
 
-class TestRecord extends Record {
-  static get attributes() {
-    return {
-      ...super.attributes,
-      custom: null
-    }
-  }
-
-  get custom() {
-    return 'overriden';
-  }
-}
+class TestRecord extends Record { }
 
 describe('.get', () => {
   test('parses default attributes', async () => {
@@ -30,12 +19,6 @@ describe('.get', () => {
 
     expect(testRecord.id).toBe('123');
     expect(testRecord.created_at).toBeInstanceOf(Date);
-  });
-
-  test('parses custom attributes', async () => {
-    const testRecord = await TestRecord.get('123');
-
-    expect(testRecord.custom).toBe('overriden');
   });
 });
 
@@ -46,19 +29,5 @@ describe('.save', () => {
 
     expect(typeof testRecord.id).toBe('string');
     expect(testRecord.created_at).toBeInstanceOf(Date);
-  });
-});
-
-describe('attribute getters/setters', () => {
-  test('are set by default if defined in attributes()', () => {
-    const testRecord = new TestRecord();
-
-    expect('custom' in testRecord).toBe(true);
-  });
-
-  test('are overridable', () => {
-    const testRecord = new TestRecord();
-
-    expect(testRecord.custom).toEqual('overriden');
   });
 });

--- a/assets/javascripts/lib/records/record.test.js
+++ b/assets/javascripts/lib/records/record.test.js
@@ -2,7 +2,7 @@ import Record from './record';
 
 const session = {
   async getFile() {
-    return JSON.stringify({ id: '123', createdAt: new Date() });
+    return JSON.stringify({ id: '123', created_at: new Date() });
   },
   async putFile() {
     return true;
@@ -29,7 +29,7 @@ describe('.get', () => {
     const testRecord = await TestRecord.get('123');
 
     expect(testRecord.id).toBe('123');
-    expect(testRecord.createdAt).toBeInstanceOf(Date);
+    expect(testRecord.created_at).toBeInstanceOf(Date);
   });
 
   test('parses custom attributes', async () => {
@@ -40,12 +40,12 @@ describe('.get', () => {
 });
 
 describe('.save', () => {
-  test('sets id and createdAt', async () => {
+  test('sets id and created_at', async () => {
     const testRecord = new TestRecord();
     await testRecord.save();
 
     expect(typeof testRecord.id).toBe('string');
-    expect(testRecord.createdAt).toBeInstanceOf(Date);
+    expect(testRecord.created_at).toBeInstanceOf(Date);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "random-js": "^2.1.0",
     "randomstring": "^1.1.5",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "uuid": "^3.3.2"
   }
 }


### PR DESCRIPTION
Changes to the "Pointer File":

- `url` doesn't include /name.ext anymore;
- there's a new attribute `name` for name.txt;
- LONG_HASH becomes UUID;

Other notes:
- Maintains compatibility with legacy files;
- Other platforms must interpret the new `name` attribute for new files, rather than getting its value from `url` (/LONG_HASH/name.txt), which is now just /UUI;